### PR TITLE
4 4 widget sizes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,8 +12,8 @@ class App extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Test app title...',
-      home: SightDetailsScreen(sight: mocks[0]),
-//      home: SightListScreen(),
+//      home: SightDetailsScreen(sight: mocks[0]),
+      home: SightListScreen(),
 //      home: MyFirstWidget_Stateless(),
     );
   }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -3,13 +3,13 @@ import 'package:places/domain/sight.dart';
 
 class SightCard extends StatelessWidget {
   final Sight sight;
+
   const SightCard({Key key, @required this.sight}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.only(left: 16, right: 16, bottom: 16),
-      height: 220,
+    return AspectRatio(
+      aspectRatio: 3 / 2,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -19,9 +19,8 @@ class SightCard extends StatelessWidget {
                 height: 100,
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(20),
-                    topRight: Radius.circular(20)
-                  ),
+                      topLeft: Radius.circular(20),
+                      topRight: Radius.circular(20)),
                   color: Colors.cyan,
                 ),
               ),
@@ -31,11 +30,10 @@ class SightCard extends StatelessWidget {
                 child: Text(
                   sight.type,
                   style: TextStyle(
-                    color: Colors.white,
-                    fontFamily: "Roboto",
-                    fontWeight: FontWeight.bold,
-                    fontSize: 14
-                  ),
+                      color: Colors.white,
+                      fontFamily: "Roboto",
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14),
                 ),
               ),
               Positioned(
@@ -60,15 +58,24 @@ class SightCard extends StatelessWidget {
                 fontSize: 16),
           ),
           SizedBox(height: 2),
-          Text(
-            sight.details,
-            maxLines: 3,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-                color: Color(0xFF7C7E92),
-                fontFamily: "Roboto",
-                fontSize: 12),
+          Expanded(
+            // child: FractionallySizedBox(
+            //   widthFactor: 0.5,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                  maxWidth: MediaQuery.of(context).size.width / 2),
+              child: Text(
+                sight.details,
+                // maxLines: 3,
+                // overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                    color: Color(0xFF7C7E92),
+                    fontFamily: "Roboto",
+                    fontSize: 14),
+              ),
+            ),
           ),
+          SizedBox(height: 10),
         ],
       ),
     );

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -61,9 +61,9 @@ class SightCard extends StatelessWidget {
           Expanded(
             // child: FractionallySizedBox(
             //   widthFactor: 0.5,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                  maxWidth: MediaQuery.of(context).size.width / 2),
+            // child: ConstrainedBox(
+            //   constraints: BoxConstraints(
+            //       maxWidth: MediaQuery.of(context).size.width / 2),
               child: Text(
                 sight.details,
                 // maxLines: 3,
@@ -73,7 +73,7 @@ class SightCard extends StatelessWidget {
                     fontFamily: "Roboto",
                     fontSize: 14),
               ),
-            ),
+//            ),
           ),
           SizedBox(height: 10),
         ],

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -11,23 +11,24 @@ class _SightListScreenState extends State<SightListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        //backgroundColor: Colors.white,
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        toolbarHeight: 150,
-        title: Text(
-          'Список\nинтересных мест',
-          textAlign: TextAlign.left,
-          maxLines: 2,
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Roboto-Regular.ttf',
-            fontSize: 32,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
+      appBar: SightAppBar(),
+      // appBar: AppBar(
+      //   //backgroundColor: Colors.white,
+      //   backgroundColor: Colors.transparent,
+      //   elevation: 0,
+      //   toolbarHeight: 150,
+      //   title: Text(
+      //     'Список\nинтересных мест',
+      //     textAlign: TextAlign.left,
+      //     maxLines: 2,
+      //     style: TextStyle(
+      //       color: Colors.black,
+      //       fontFamily: 'Roboto-Regular.ttf',
+      //       fontSize: 32,
+      //       fontWeight: FontWeight.bold,
+      //     ),
+      //   ),
+      // ),
       body: SingleChildScrollView(
         child: Column(
           children: [
@@ -42,4 +43,31 @@ class _SightListScreenState extends State<SightListScreen> {
       ),
     );
   }
+}
+
+class SightAppBar extends StatelessWidget implements PreferredSizeWidget {
+
+  const SightAppBar({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+          left: 16.0, top: 64.0, right: 16.0, bottom: 16.0),
+      child: Text(
+        'Список\nинтересных мест',
+        textAlign: TextAlign.left,
+        maxLines: 2,
+        style: TextStyle(
+          color: Colors.black,
+          fontFamily: 'Roboto-Regular.ttf',
+          fontSize: 32,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(150.0);
 }


### PR DESCRIPTION
1. В SightCard использован ConstrainedBox (хотя логичнее FractionallySizedBox(widthFactor: 0.5). Т.к. ограничения распространяются сверху вниз, то они действуют на подчиненный виджет Text.
2. Отступ с помощью SizedBox был ранее добавлен в ДЗ.
4. Применен AspectRatio в виджете SightCard.
5. class SightAppBar extends StatelessWidget implements PreferredSizeWidget

![image](https://user-images.githubusercontent.com/56135310/105081457-46449180-5aa3-11eb-9ab4-f05bb8aa5457.png)
