### PR TITLE
7-1-splash_screen-AdvancedFutures

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:places/ui/screen/res/themes.dart';
 import 'package:places/ui/screen/filters_screen.dart';
 import 'package:places/ui/screen/settings_screen.dart';
 import 'package:places/ui/screen/onboarding_screen.dart';
+import 'package:places/ui/screen/splash_screen.dart';
 
 void main() => runApp(App());
 
@@ -30,7 +31,8 @@ class _AppState extends State<App> {
 //      home: VisitingScreen(),
 //      home: SightListScreen(),
 //      home: SightDetailsScreen(sight: mocks[4]),
-      home: OnboardingScreen(),
+//      home: OnboardingScreen(),
+      home: SplashScreen(),
     );
   }
 }

--- a/lib/ui/screen/splash_screen.dart
+++ b/lib/ui/screen/splash_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:places/ui/screen/onboarding_screen.dart';
+
+/// Стартовый экран приложения
+class SplashScreen extends StatefulWidget {
+  @override
+  _SplashScreenState createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  Future<void> _isInitialized;
+
+  @override
+  void initState() {
+    print('initState - stated.');
+    super.initState();
+    _navigateToNext();
+    print('initState - finished.');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.height,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Colors.yellow,
+              Colors.green,
+            ],
+          ),
+        ),
+        child: Center(
+          child: Container(
+            width: 160,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.white,
+            ),
+            child: Center(
+              child: Image.asset(
+                'res/Map Full.png',
+                width: 80,
+                color: Colors.green,
+                fit: BoxFit.fitWidth,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _navigateToNext() {
+    print('_navigateToNext - stated.');
+    _isInitialized = Future<void>.delayed(Duration(seconds: 2), () {
+      print(
+          'Время показа SplashScreen (2 секунды) истекло. Переход на следующий экран.');
+      Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => OnboardingScreen()));
+    });
+    print('_navigateToNext - finished.');
+  }
+}


### PR DESCRIPTION
I/flutter (  629): initState - stated.
I/flutter (  629): _navigateToNext - stated.
I/flutter (  629): _navigateToNext - finished.
I/flutter (  629): initState - finished.
I/flutter (  629): Время показа SplashScreen (2 секунды) истекло. Переход на следующий экран.

Т.е. вызываются initState и _navigateToNext, они оба завершаются и через 2 секунды асинхронно отрабатывается закрытие SplashScreen-а и переход на следующий экран (пока безусловно на OnboardingScreen).