### PR TITLE
9-1-3-filters_screen-ScreenSize

### DIFF
--- a/lib/ui/screen/filters_screen.dart
+++ b/lib/ui/screen/filters_screen.dart
@@ -93,20 +93,46 @@ class _FiltersScreenState extends State<FiltersScreen> {
               SizedBox(
                 height: 24,
               ),
-              GridView.count(
-                crossAxisCount: 3,
-                physics: NeverScrollableScrollPhysics(),
-                shrinkWrap: true,
-                children: List.generate(sightTypeMocks.length, (index) {
-                  return Center(
-                    child: _SightTypeWidget(
-                      sightType: sightTypeMocks[index],
-                      onTap: (SightType sightType) => setState(
-                          () => sightType.isChecked = !sightType.isChecked),
+              MediaQuery.of(context).size.height > 800
+                  ? Container(
+                      height: 256,
+                      child: GridView.count(
+                        crossAxisCount: 3,
+                        physics: AlwaysScrollableScrollPhysics(),
+                        shrinkWrap: true,
+                        children: List.generate(sightTypeMocks.length, (index) {
+                          return SizedBox(
+                            width: 128,
+                            height: 128,
+                            child: Center(
+                              child: _SightTypeWidget(
+                                sightType: sightTypeMocks[index],
+                                onTap: (SightType sightType) => setState(() =>
+                                    sightType.isChecked = !sightType.isChecked),
+                              ),
+                            ),
+                          );
+                        }),
+                      ),
+                    )
+                  : Container(
+                      height: 128,
+                      child: ListView.builder(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: sightTypeMocks.length,
+                        itemBuilder: (context, index) => SizedBox(
+                          width: 128,
+                          height: 128,
+                          child: Center(
+                            child: _SightTypeWidget(
+                              sightType: sightTypeMocks[index],
+                              onTap: (SightType sightType) => setState(() =>
+                                  sightType.isChecked = !sightType.isChecked),
+                            ),
+                          ),
+                        ),
+                      ),
                     ),
-                  );
-                }),
-              ),
               SizedBox(
                 height: 60.0,
               ),


### PR DESCRIPTION
Если экран большой, то список типов достопримечательностей показываем в две строки и скролируем по вертикали.
![image](https://user-images.githubusercontent.com/56135310/111918942-7d7df180-8a98-11eb-9588-d943b2e0918a.png)
Если экран маленький,  то список типов достопримечательностей показываем в одну строку и скролируем по горизонтали.
![image](https://user-images.githubusercontent.com/56135310/111918957-8a024a00-8a98-11eb-88a3-da4cc1ce45ec.png)